### PR TITLE
Don't include .mll or .mly files as either implementation or interface files

### DIFF
--- a/build.js
+++ b/build.js
@@ -994,7 +994,15 @@ var getOCamldepFlags = function(packageConfig) {
       return '';
     }
     var kind = maybeSourceKind(sourceFile, packageConfig);
-    return kind === '.ml' ? ' -impl ' + sourceFile : ' -intf ' + sourceFile;
+    // Be careful to not include e.g. .mll .mly files
+    if (kind === '.ml') {
+      return ' -impl ' + sourceFile;
+    } else if (kind === '.mli') {
+      return ' -intf ' + sourceFile;
+    } else {
+      // XXX: Should perhaps have a better handler for this.
+      return '';
+    }
   });
   var ppFlags = packageConfig.packageJSON.CommonML.preprocessor ? [
     '-pp ' + packageConfig.packageJSON.CommonML.preprocessor


### PR DESCRIPTION
Was causing issues when trying to compile a project that used menhir and associated files. This alone isn't enough to get Menhir working (obviously need to change the `OCAMLYACC` variable, and make it so some of the flags can be passed through) but it seems like a good idea regardless.
