### PR TITLE
Add support for compiling libraries with dependencies on foreign code.

### DIFF
--- a/ExampleProjects/ForeignDependencyExample/package.json
+++ b/ExampleProjects/ForeignDependencyExample/package.json
@@ -1,0 +1,13 @@
+{
+  "version": "1.0.0",
+  "description": "Simple example with foreign dependencies in OCaml",
+  "license": "BSD",
+  "name": "ForeignDependencyExample",
+  "dependencies": {
+    "OcamlAsciiTable": "git://github.com/chenglou/ascii-table.git",
+    "CommonML": "git://github.com/jordwalke/CommonML.git"
+  },
+  "CommonML": {
+    "exports": ["MyPublicModule"]
+  }
+}

--- a/ExampleProjects/ForeignDependencyExample/src/MainModule.ml
+++ b/ExampleProjects/ForeignDependencyExample/src/MainModule.ml
@@ -1,0 +1,5 @@
+open OcamlAsciiTable
+
+let () = print_endline @@ AsciiTable.table [["1";"213ad";"3";]; ["4";"5";"6"]]
+
+let () = print_endline @@ AsciiTable.table ~align:AsciiTable.Center ~style:AsciiTable.double [["1";"213ad";"3";]; ["4";"5";"6"]]


### PR DESCRIPTION
This makes two big changes:
- builds all of the dependencies with `-a` instead of `-c` and with
  their own `linkFlags`. `-a` tells the compiler that you're building a
  library and it'll cache the linker arguments inside the object file
  (which is actually a `.cma` file). This will allow us to build the
  user's package by combining all of the dependencies but without needing
  to add all of the dependencies' `linkFlags`.
- add a `foreignDependencies` in package.json which allows the library
  maker to point to a pre-built object file to be linked at link-time.
  That file can be built however you want, and can be writtin in any
  language that can build a valid object file that the ocaml compiler is
  able to handle.

An example of its usage is in our wrapper for Pcre: https://github.com/bsansouci/commonml-ocaml-pcre. There's a post install script that'll run and build the .o file for the C dependency.
