### PR TITLE
Make kebab-case turn into CamelCase for package name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
Sometimes the package name is mendated to be kebab-case (ahem Atom).
We'll hackily/intelligently transform to CamelCase as the module name.
